### PR TITLE
fix: resolve Next.js 14 metadata viewport and themeColor warnings

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 
@@ -9,7 +9,11 @@ export const metadata: Metadata = {
   description: '基于 Aihubmix OpenAI API 的智能对话应用，支持 GPT-4o 和 GPT-5 模型',
   keywords: ['AI', 'ChatBot', '人工智能', '对话', 'GPT-4o', 'GPT-5'],
   authors: [{ name: 'AI Chat Bot' }],
-  viewport: 'width=device-width, initial-scale=1',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: 'white' },
     { media: '(prefers-color-scheme: dark)', color: 'black' },
@@ -24,7 +28,6 @@ export default function RootLayout({
   return (
     <html lang="zh-CN" suppressHydrationWarning>
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </head>
       <body className={inter.className}>


### PR DESCRIPTION
## 问题描述

gpt-5 发送消息时出现 Next.js 14 metadata 配置警告：

```
⚠ Unsupported metadata viewport is configured in metadata export in /favicon.ico. Please move it to viewport export instead.
⚠ Unsupported metadata themeColor is configured in metadata export in /favicon.ico. Please move it to viewport export instead.
```

## 解决方案

根据 Next.js 14 的新要求，将 `viewport` 和 `themeColor` 配置从 `metadata` export 移动到单独的 `viewport` export 中。

## 更改内容

1. **添加 Viewport 类型导入**：从 `next` 导入 `Viewport` 类型
2. **创建独立的 viewport export**：
   - 将 `viewport` 和 `themeColor` 从 `metadata` 中移除
   - 创建新的 `viewport` export 使用正确的 Next.js 14 语法
3. **移除重复的 meta 标签**：删除 `<head>` 中重复的 viewport meta 标签

## 修改文件

- `src/app/layout.tsx`

## 测试

- ✅ 符合 Next.js 14 metadata API 要求
- ✅ 移除了警告信息
- ✅ 保持了原有的 viewport 和主题色功能

## 相关链接

- [Next.js 14 Viewport API 文档](https://nextjs.org/docs/app/api-reference/functions/generate-viewport)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author