### PR TITLE
Fix JWT payload type and conversation fetch

### DIFF
--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -135,7 +135,7 @@ export async function PUT(request: NextRequest) {
     }
 
     // 返回更新后的对话
-    const updatedConversation = await getConversation(id);
+    const updatedConversation = await getConversation(id, auth.sub);
     return NextResponse.json(updatedConversation);
   } catch (error) {
     console.error('Update conversation error:', error);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -28,7 +28,10 @@ export interface JWTPayload {
   exp?: number;
 }
 
-export function signJWT(payload: JWTPayload, expiresInSec?: number) {
+export function signJWT(
+  payload: Omit<JWTPayload, 'iat' | 'exp'>,
+  expiresInSec?: number
+) {
   const header = { alg: ALG, typ: 'JWT' };
   const now = Math.floor(Date.now() / 1000);
   const body: JWTPayload = { ...payload, iat: now };


### PR DESCRIPTION
## Summary
- fix signJWT to accept payload without iat and exp
- ensure conversation update retrieves user-scoped conversation

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Connection error to aihubmix.com)


------
https://chatgpt.com/codex/tasks/task_e_689ddfd65ec483269236b7fb1522f60b