### PR TITLE
Handle start events in ChatInterface

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -172,6 +172,11 @@ export default function ChatInterface() {
                     setReasoningContent(reasoning);
                     break;
 
+                  case 'start':
+                  case 'tool_call_start':
+                    // 起始事件或工具调用开始事件，无需特殊处理
+                    break;
+
                   case 'function_result':
                   case 'tool_result':
                     assistantContent += `\n\n**工具调用结果 (${data.tool || data.function}):**\n${data.result}`;


### PR DESCRIPTION
## Summary
- ignore `start` and `tool_call_start` SSE events in ChatInterface to stop console warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689eb1574584832681c60dc3a087dbd5